### PR TITLE
Support for Beautiful soup 4

### DIFF
--- a/xsser-public/core/crawler.py
+++ b/xsser-public/core/crawler.py
@@ -32,7 +32,7 @@ import curlcontrol
 import threadpool
 from Queue import Queue
 from collections import defaultdict
-from BeautifulSoup import BeautifulSoup
+from bs4 import BeautifulSoup
 
 class EmergencyLanding(Exception):
     pass

--- a/xsser-public/core/dork.py
+++ b/xsser-public/core/dork.py
@@ -24,7 +24,7 @@ import urlparse
 import urllib2
 import traceback
 urllib2.socket.setdefaulttimeout(5.0)
-from BeautifulSoup import BeautifulSoup
+from bs4 import BeautifulSoup
 
 DEBUG = 1
 

--- a/xsser-public/core/post/shorter.py
+++ b/xsser-public/core/post/shorter.py
@@ -25,7 +25,7 @@ Post processing filter to make reservations on shortered links.
 import urllib
 import pycurl
 from cStringIO import StringIO
-from BeautifulSoup import BeautifulSoup
+from bs4 import BeautifulSoup
 
 class ShortURLReservations(object):
     #options = [['-foo!', 'do stuff']]


### PR DESCRIPTION
With the release of Beautiful Soap 4 the import function is changed.

If you have Beautiful Soap 3 and run **XSSER** you will get an error like

```
Traceback (most recent call last):
  File "/usr/local/bin/xsser", line 24, in <module>
    from core.main import xsser
  File "/usr/local/lib/python2.7/dist-packages/xsser-1.6-py2.7.egg/core/main.py", line 35, in <module>
    from core.dork import Dorker
  File "/usr/local/lib/python2.7/dist-packages/xsser-1.6-py2.7.egg/core/dork.py", line 27, in <module>
    from BeautifulSoup import BeautifulSoup
ImportError: No module named BeautifulSoup
```

Most code written against Beautiful Soup 3 will work against Beautiful Soup 4 with one simple change. All you should have to do is change the package name from _BeautifulSoup_ to _bs4_